### PR TITLE
chore: Bump docker/build-push-action from v2 to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Build multi-architecture images
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
## Description

Bump [docker/build-push-action](https://github.com/docker/build-push-action) from v2 to v4.